### PR TITLE
OP-72188 PyOpsview breaks with multiple systems

### DIFF
--- a/pyopsview/v2/client.py
+++ b/pyopsview/v2/client.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# Copyright (C) 2003-2025 ITRS Group Ltd. All rights reserved
 
 from __future__ import absolute_import
 from __future__ import division
@@ -42,7 +43,7 @@ class Client(object):
         self._username = username
         self._password = password
         self._session = requests.session()
-        self._session.headers = Client.default_headers
+        self._session.headers = Client.default_headers.copy()
         self._authenticate()
         self._load_schema = self._get_schema_loader(strict)
         self._init_clients()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import setup, find_packages
 
-PYOPSVIEW_VERSION = '6.2.4'
+PYOPSVIEW_VERSION = '6.2.5'
 
 with open('README.md', 'r') as fno:
     LONG_DESCRIPTION = fno.read()


### PR DESCRIPTION
When using pyopsview with 2 Opsview systems, creating a connection to a second system will break the first connection.

The default headers for all connections are set from a specific dictionary.  However, Python will create a reference between two dictionaries by default, rather than copy the data.  This results in the internally stored data being used by all connections created.

The fix is to force the internal dictionary to be copied, not referenced.